### PR TITLE
Implement support for "serde(flatten)".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ default = ["chrono"]
 
 [dependencies]
 openapi = { git = "https://github.com/boxdot/openapi", rev = "e42474a" }
-# serde = { version = "1.0", features = ["derive"] }
 openapi-schema-derive = { path = "openapi-schema-derive" }
 serde_json = "1.0"
 
 chrono = { version = "0.4", features = ["serde"], optional = true }
+
+[dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ The above example generates the following schema:
 * [x] `Vec<T>`
 * [x] Simple Rust structs (no tuple and unit structs)
 * [x] C-like Rust enums (no non-trivial variants)
-* [x] Doc comments are used as `title` and `description` of the type.
+* [x] Doc comments are used as `title` and `description` of the schema.
+* [x] Doc comments of attributes are used as `description` of the property.
+* [x] Support for `serde(flatten)`.
 
 TODO
 

--- a/openapi-schema-derive/src/lib.rs
+++ b/openapi-schema-derive/src/lib.rs
@@ -7,7 +7,7 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{
     parse_macro_input, AttrStyle, Attribute, Data, DataEnum, DataStruct, DeriveInput, Field,
-    Fields, Lit, Meta, MetaNameValue, Type,
+    Fields, Lit, Meta, MetaList, MetaNameValue, NestedMeta, Type,
 };
 
 #[proc_macro_derive(OpenapiSchema)]
@@ -48,22 +48,56 @@ fn derive_for_struct(input: &syn::DeriveInput) -> TokenStream {
                 if !already_generated {
                     let mut properties = std::collections::BTreeMap::new();
                     let mut required = Vec::new();
-                    for (name, prop, doc, optional) in vec![#(#properties)*] {
-                        let prop_schema = match prop {
-                            ObjectOrReference::Object(mut schema) => {
-                                if !doc.is_empty() {
-                                    schema.description = Some(doc.into());
+
+                    // buffer for collecting flattened schemas
+                    let flatten_spec = &mut openapi::v3_0::Spec::default();
+
+                    for (name, prop, doc, optional, flatten) in vec![#(#properties)*] {
+                        if flatten {
+                            // get schema from flattened schemas
+                            let mut flatten_schemas = flatten_spec.components
+                                .as_mut()
+                                .and_then(|c| c.schemas.as_mut())
+                                .expect("logic error: missing flatten schemas");
+
+                            let prop_schema = flatten_schemas.remove(name).expect("logic error");
+                            let prop_schema = match prop_schema {
+                                ObjectOrReference::Object(schema) => schema,
+                                _ => panic!("unexpected reference"),
+                            };
+
+                            let inner_properties = prop_schema.properties
+                                .unwrap_or_else(Default::default);
+                            for (inner_name, inner_prop_schema) in inner_properties
+                            {
+                                properties.insert(inner_name.clone(), inner_prop_schema);
+                                if prop_schema.required
+                                    .as_ref()
+                                    .map(|r| r.contains(&inner_name))
+                                    .unwrap_or(false)
+                                {
+                                    required.push(inner_name);
                                 }
-                                schema
-                            },
-                            ObjectOrReference::Ref{ ref_path } => Schema {
-                                ref_path: Some(ref_path),
-                                ..Schema::default()
                             }
-                        };
-                        properties.insert(String::from(name), prop_schema);
-                        if !optional {
-                            required.push(String::from(name));
+                        } else {
+                            // create new schema
+                            let prop_schema = match prop {
+                                ObjectOrReference::Object(mut schema) => {
+                                    if !doc.is_empty() {
+                                        schema.description = Some(doc.into());
+                                    }
+                                    schema
+                                },
+                                ObjectOrReference::Ref { ref_path } => Schema {
+                                    ref_path: Some(ref_path),
+                                    ..Schema::default()
+                                }
+                            };
+
+                            properties.insert(String::from(name), prop_schema);
+                            if !optional {
+                                required.push(String::from(name));
+                            }
                         }
                     }
 
@@ -87,10 +121,16 @@ fn derive_for_struct(input: &syn::DeriveInput) -> TokenStream {
                         ..Default::default()
                     };
 
-                    let components = spec.components.get_or_insert_with(Components::default);
-                    let schemas = components.schemas
-                        .get_or_insert_with(std::collections::BTreeMap::new);
+                    let components = spec.components.get_or_insert_with(Default::default);
+                    let schemas = components.schemas.get_or_insert_with(Default::default);
                     schemas.insert(String::from(name), ObjectOrReference::Object(schema));
+
+                    let flatten_schemas = flatten_spec.components
+                        .as_mut()
+                        .and_then(|c| c.schemas.take());
+                    if let Some(mut flatten_schemas) = flatten_schemas {
+                        schemas.extend(flatten_schemas);
+                    }
                 }
                 ObjectOrReference::Ref { ref_path }
             }
@@ -112,15 +152,28 @@ fn collect_struct_properties(data: &Data) -> Vec<proc_macro2::TokenStream> {
                 let ty = &field.ty;
                 let doc = doc_string(&field.attrs);
                 let optional = is_optional(&field);
-                let gen = quote! {
-                    (
-                        stringify!(#field_name),
-                        <#ty as OpenapiSchema>::generate_schema(spec),
-                        #doc,
-                        #optional,
-                    ),
-                };
-                gen
+                let flatten = has_serde_flatten(field);
+                if flatten {
+                    quote! {
+                        (
+                            stringify!(#ty),
+                            <#ty as OpenapiSchema>::generate_schema(flatten_spec),
+                            #doc,
+                            #optional,
+                            #flatten,
+                        ),
+                    }
+                } else {
+                    quote! {
+                        (
+                            stringify!(#field_name),
+                            <#ty as OpenapiSchema>::generate_schema(spec),
+                            #doc,
+                            #optional,
+                            #flatten,
+                        ),
+                    }
+                }
             })
             .collect(),
         _ => panic!("logic error"),
@@ -135,6 +188,24 @@ fn is_optional(field: &Field) -> bool {
         }
         _ => false,
     }
+}
+
+fn has_serde_flatten(field: &Field) -> bool {
+    field.attrs.iter().any(|attr| {
+        if attr.style == AttrStyle::Outer && attr.path.is_ident("serde") {
+            let meta = attr.interpret_meta();
+            let ls = match meta {
+                Some(Meta::List(MetaList { nested, .. })) => nested,
+                _ => return false,
+            };
+            ls.into_iter().any(|item| match item {
+                NestedMeta::Meta(Meta::Word(ref ident)) => ident == "flatten",
+                _ => false,
+            })
+        } else {
+            false
+        }
+    })
 }
 
 /// Returns the summary of the doc (first paragraph) and the optional body (other paragraphs).

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,79 @@
+use openapi::v3_0::{ObjectOrReference, Spec};
+use openapi_schema::OpenapiSchema;
+use serde::Serialize;
+
+#[cfg(feature = "chrono")]
+#[test]
+fn test_datetime() {
+    #[derive(OpenapiSchema)]
+    #[allow(dead_code)]
+    struct DatesContainer {
+        date: chrono::Date<chrono::Utc>,
+        date_time: chrono::DateTime<chrono::Utc>,
+    }
+
+    let mut spec = Spec::default();
+    DatesContainer::generate_schema(&mut spec);
+    println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+
+    let schemas = spec.components.as_ref().unwrap().schemas.as_ref().unwrap();
+    assert!(schemas.contains_key("DatesContainer"));
+
+    let c = match schemas.get("DatesContainer") {
+        Some(ObjectOrReference::Object(ref c)) => c,
+        _ => panic!("unexpected reference"),
+    };
+
+    assert_eq!(
+        c.required,
+        Some(vec![String::from("date"), String::from("date_time")])
+    );
+
+    let d = &c.properties.as_ref().unwrap().get("date").unwrap();
+    assert_eq!(d.schema_type, Some("string".to_owned()));
+    assert_eq!(d.format, Some("date".to_owned()));
+
+    let dt = &c.properties.as_ref().unwrap().get("date_time").unwrap();
+    assert_eq!(dt.schema_type, Some("string".to_owned()));
+    assert_eq!(dt.format, Some("date-time".to_owned()));
+}
+
+#[test]
+fn test_flatten() {
+    #[derive(OpenapiSchema, Serialize)]
+    struct A {
+        primitive_field: u64,
+    }
+
+    #[derive(OpenapiSchema, Serialize)]
+    struct B {
+        inner: A,
+    }
+
+    #[derive(OpenapiSchema, Serialize)]
+    #[allow(dead_code)]
+    struct C {
+        outer: u64,
+        #[serde(flatten)]
+        flatten: B,
+    }
+
+    let mut spec = Spec::default();
+    C::generate_schema(&mut spec);
+    println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+
+    let schemas = spec.components.as_ref().unwrap().schemas.as_ref().unwrap();
+    assert!(schemas.contains_key("A"));
+    assert!(!schemas.contains_key("B"));
+
+    let c = match schemas.get("C") {
+        Some(ObjectOrReference::Object(ref user)) => user,
+        _ => panic!("unexpected reference"),
+    };
+
+    let properties = c.properties.as_ref().unwrap();
+    assert!(properties.contains_key("outer"));
+    assert!(properties.contains_key("inner"));
+    assert!(!properties.contains_key("flatten"));
+    assert!(!properties.contains_key("primitive_field"));
+}

--- a/tests/petstore.rs
+++ b/tests/petstore.rs
@@ -168,42 +168,6 @@ fn test_pet_derive() {
     );
 }
 
-#[cfg(feature = "chrono")]
-#[test]
-fn test_datetime() {
-    #[derive(OpenapiSchema)]
-    #[allow(dead_code)]
-    struct DatesContainer {
-        date: chrono::Date<chrono::Utc>,
-        date_time: chrono::DateTime<chrono::Utc>,
-    }
-
-    let mut spec = Spec::default();
-    DatesContainer::generate_schema(&mut spec);
-    println!("{}", serde_json::to_string_pretty(&spec).unwrap());
-
-    let schemas = spec.components.as_ref().unwrap().schemas.as_ref().unwrap();
-    assert!(schemas.contains_key("DatesContainer"));
-
-    let c = match schemas.get("DatesContainer") {
-        Some(ObjectOrReference::Object(ref c)) => c,
-        _ => panic!("unexpected reference"),
-    };
-
-    assert_eq!(
-        c.required,
-        Some(vec![String::from("date"), String::from("date_time")])
-    );
-
-    let d = &c.properties.as_ref().unwrap().get("date").unwrap();
-    assert_eq!(d.schema_type, Some("string".to_owned()));
-    assert_eq!(d.format, Some("date".to_owned()));
-
-    let dt = &c.properties.as_ref().unwrap().get("date_time").unwrap();
-    assert_eq!(dt.schema_type, Some("string".to_owned()));
-    assert_eq!(dt.format, Some("date-time".to_owned()));
-}
-
 #[test]
 fn test_attr_doc() {
     let mut spec = Spec::default();


### PR DESCRIPTION
Not the nicest code, I have to admit, but it works. Also, moved pets non-related tests into a separate runner `integration`. It is easier to use it with `cargo expand` when debugging generated code.

Resolves  #4.