### PR TITLE
add btreemap serialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,29 @@ where
     }
 }
 
+impl<K, V> OpenapiSchema for std::collections::BTreeMap<K, V>
+where
+    V: OpenapiSchema,
+{
+    fn generate_schema(spec: &mut Spec) -> ObjectOrReference<Schema> {
+        let values = V::generate_schema(spec);
+
+        let items_schema = match values {
+            ObjectOrReference::Object(schema) => schema,
+            ObjectOrReference::Ref { ref_path } => Schema {
+                ref_path: Some(ref_path),
+                ..Schema::default()
+            },
+        };
+
+        ObjectOrReference::Object(Schema {
+            schema_type: Some("object".into()),
+            additional_properties: Some(ObjectOrReference::Object(Box::new(items_schema))),
+            ..Schema::default()
+        })
+    }
+}
+
 #[cfg(feature = "chrono")]
 impl<T> OpenapiSchema for chrono::DateTime<T>
 where


### PR DESCRIPTION
add the support for BTreeMap as stated in https://swagger.io/docs/specification/data-models/dictionaries/

Since openapi supports only strings as key, I do not care about the `K` type.

It might not be perfect when is type is something that serialize to string. For example for trivial enums we could add some properties to the object (a bit like the [fixed keys](https://swagger.io/docs/specification/data-models/dictionaries/) section, but without the required part.

But I think it's not that important to support those kind of additional constraints.