### PR TITLE
supports isize and usize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ impl OpenapiSchema for String {
 impl OpenapiSchema for i64 {
     fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
         ObjectOrReference::Object(Schema {
-            schema_type: Some("number".into()),
+            schema_type: Some("integer".into()),
             format: Some("int64".into()),
             ..Default::default()
         })
@@ -32,9 +32,28 @@ impl OpenapiSchema for i64 {
 impl OpenapiSchema for u64 {
     fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
         ObjectOrReference::Object(Schema {
-            schema_type: Some("number".into()),
+            schema_type: Some("integer".into()),
             format: Some("int64".into()),
             minimum: Some(Value::Number(Number::from(0))),
+            ..Default::default()
+        })
+    }
+}
+
+impl OpenapiSchema for usize {
+    fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
+        ObjectOrReference::Object(Schema {
+            schema_type: Some("integer".into()),
+            minimum: Some(Value::Number(Number::from(0))),
+            ..Default::default()
+        })
+    }
+}
+
+impl OpenapiSchema for isize {
+    fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
+        ObjectOrReference::Object(Schema {
+            schema_type: Some("integer".into()),
             ..Default::default()
         })
     }
@@ -43,7 +62,7 @@ impl OpenapiSchema for u64 {
 impl OpenapiSchema for i32 {
     fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
         ObjectOrReference::Object(Schema {
-            schema_type: Some("number".into()),
+            schema_type: Some("integer".into()),
             format: Some("int32".into()),
             ..Default::default()
         })
@@ -53,7 +72,7 @@ impl OpenapiSchema for i32 {
 impl OpenapiSchema for u32 {
     fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
         ObjectOrReference::Object(Schema {
-            schema_type: Some("number".into()),
+            schema_type: Some("integer".into()),
             format: Some("int32".into()),
             minimum: Some(Value::Number(Number::from(0))),
             ..Default::default()
@@ -64,7 +83,7 @@ impl OpenapiSchema for u32 {
 impl OpenapiSchema for u16 {
     fn generate_schema(_spec: &mut Spec) -> ObjectOrReference<Schema> {
         ObjectOrReference::Object(Schema {
-            schema_type: Some("number".into()),
+            schema_type: Some("integer".into()),
             format: Some("int32".into()),
             minimum: Some(Value::Number(Number::from(0))),
             ..Default::default()

--- a/tests/petstore.rs
+++ b/tests/petstore.rs
@@ -114,7 +114,7 @@ fn test_tag_derive() {
 
     assert!(properties.contains_key("id"));
     let id = properties.get("id").unwrap();
-    assert_eq!(id.schema_type, Some("number".into()));
+    assert_eq!(id.schema_type, Some("integer".into()));
     assert_eq!(id.format, Some("int64".into()));
 
     assert!(properties.contains_key("name"));


### PR DESCRIPTION
and also change the schema_type from `number` to the more precise `integer`

For u|isize, it's not very clear if we can drop the `format` field.

It seems ok for [swagger v3 doc](https://swagger.io/docs/specification/data-models/data-types/#numbers), but the case is not listed in [openapi](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#data-types).

I supposed it was a mistake from openapi, but we could also maybe do some clever trick with `std::mem::size_of` ?