### PR TITLE
Support enum with doc string

### DIFF
--- a/tests/enum_with_doc.rs
+++ b/tests/enum_with_doc.rs
@@ -1,0 +1,122 @@
+use openapi::v3_0::{ObjectOrReference, Spec};
+use openapi_schema::OpenapiSchema;
+
+#[test]
+fn test_enum_with_doc() {
+    /// Pet status in the store
+    #[derive(OpenapiSchema)]
+    #[allow(dead_code)]
+    pub enum Status {
+        Available,
+        Pending,
+        /// Already sold
+        Sold,
+    }
+    let mut spec = Spec::default();
+    Status::generate_schema(&mut spec);
+    println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+
+    let schemas = spec.components.as_ref().unwrap().schemas.as_ref().unwrap();
+    let status = match schemas.get("Status") {
+        Some(ObjectOrReference::Object(ref tag)) => tag,
+        _ => panic!("unexpected reference"),
+    };
+
+    assert_eq!(
+        status.description,
+        Some(
+            r#"Pet status in the store
+* Sold: Already sold"#
+                .to_owned()
+        )
+    );
+    assert_eq!(status.schema_type, Some("string".to_owned()));
+    assert_eq!(
+        status.enum_values,
+        Some(vec![
+            "Available".to_owned(),
+            "Pending".to_owned(),
+            "Sold".to_owned()
+        ])
+    );
+}
+
+#[test]
+fn test_enum_without_doc() {
+    #[derive(OpenapiSchema)]
+    #[allow(dead_code)]
+    pub enum Status {
+        /// some clever comment
+        Available,
+        Pending,
+        /// Already sold
+        Sold,
+    }
+    let mut spec = Spec::default();
+    Status::generate_schema(&mut spec);
+    println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+
+    let schemas = spec.components.as_ref().unwrap().schemas.as_ref().unwrap();
+    let status = match schemas.get("Status") {
+        Some(ObjectOrReference::Object(ref tag)) => tag,
+        _ => panic!("unexpected reference"),
+    };
+
+    assert_eq!(
+        status.description,
+        Some(
+            r#"
+* Available: some clever comment
+* Sold: Already sold"#
+                .to_owned()
+        )
+    );
+    assert_eq!(status.schema_type, Some("string".to_owned()));
+    assert_eq!(
+        status.enum_values,
+        Some(vec![
+            "Available".to_owned(),
+            "Pending".to_owned(),
+            "Sold".to_owned()
+        ])
+    );
+}
+
+#[test]
+fn test_enum_fail() {
+    #[derive(OpenapiSchema)]
+    #[allow(dead_code)]
+    pub enum Status {
+        Available(usize),
+        Pending,
+        /// Already sold
+        Sold,
+    }
+    let mut spec = Spec::default();
+    Status::generate_schema(&mut spec);
+    println!("{}", serde_json::to_string_pretty(&spec).unwrap());
+
+    let schemas = spec.components.as_ref().unwrap().schemas.as_ref().unwrap();
+    let status = match schemas.get("Status") {
+        Some(ObjectOrReference::Object(ref tag)) => tag,
+        _ => panic!("unexpected reference"),
+    };
+
+    assert_eq!(
+        status.description,
+        Some(
+            r#"
+* Sold: Already sold"#
+                .to_owned()
+        )
+    );
+    assert_eq!(status.schema_type, Some("string".to_owned()));
+    assert_eq!(
+        status.enum_values,
+        Some(vec![
+            "Available".to_owned(),
+            "Pending".to_owned(),
+            "Sold".to_owned()
+        ])
+    );
+}


### PR DESCRIPTION
For the moment the enum could not be serialized if they had some doc comment (due to `attrs` being not empty)

This remove this constraints (I removed all the constraint because I was not able to make a non trivial enum fail, and I'm a noob with syn/quote)

I also added the enum's comment into the description of the enum.

It's not very nice, but it seems to only way to model it in openapi (and it is the advised way in the [documentation](https://swagger.io/docs/specification/data-models/enums/)